### PR TITLE
ProfileMiddleware enable by Http header

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Define env variables:
 ```dotenv
 PROFILER_ENABLE=true
 PROFILER_ENDPOINT=http://127.0.0.1:8080/api/profiler/store
-PROFILER_APP_NAME=My super app
+PROFILER_APP_NAME="My super app"
+PROFILER_MIDDLEWARE_DEFAULT_ENABLED=true
 ```
 
 ## Usage
@@ -159,3 +160,15 @@ class HomeController implements SingletonInterface
     }
 }
 ```
+
+#### Profiling strategy.
+
+By default, middleware start profiling on every request. Н
+You can configure profiling to be enabled only for certain requests.
+
+1. Set env variable PROFILER_MIDDLEWARE_DEFAULT_ENABLED to false.
+```dotenv
+PROFILER_MIDDLEWARE_DEFAULT_ENABLED=false
+```
+
+2. Pass Http header `X-Spiral-Profiler-Enable=1` for request you want to profile.

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "spiral/logger": "^3.0"
   },
   "require-dev": {
+    "nyholm/psr7": "^1.8",
     "phpunit/phpunit": "^9.5",
     "vimeo/psalm": "^5.1"
   },
@@ -37,5 +38,8 @@
     "psr-4": {
       "Spiral\\Profiler\\Tests\\": "tests/"
     }
+  },
+  "config": {
+    "sort-packages": true
   }
 }

--- a/tests/ProfilerMiddlewareTest.php
+++ b/tests/ProfilerMiddlewareTest.php
@@ -4,15 +4,13 @@ declare(strict_types=1);
 
 namespace Spiral\Profiler\Tests;
 
+use Nyholm\Psr7\ServerRequest;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
 use Spiral\Boot\Environment;
-use Spiral\Boot\EnvironmentInterface;
-use Spiral\Core\CoreInterface;
 use Spiral\Core\FactoryInterface;
-use Spiral\Profiler\ProfilerInterceptor;
 use Spiral\Profiler\ProfilerMiddleware;
 
 /**
@@ -47,12 +45,111 @@ final class ProfilerMiddlewareTest extends TestCase
         self::assertNull($tags['dispatcher']);
     }
 
+    /**
+     * @covers ::process
+     * @dataProvider dataWithHttpHeaders
+     */
+    public function testWithHttpHeaders(bool|int|string $env, array $headers, bool $shouldBeCalled = true): void
+    {
+        $profiler = $this->mockProfiler();
+
+        $factory = $this->createMock(FactoryInterface::class);
+        $factory->method('make')->willReturn($profiler);
+
+        $container = $this->createMock(ContainerInterface::class);
+        $container->method('has')->willReturn(false);
+
+        $middleware = new ProfilerMiddleware(
+            $factory,
+            $container,
+            new Environment(['PROFILER_MIDDLEWARE_DEFAULT_ENABLED' => $env])
+        );
+        $request = new ServerRequest('GET', '/foo/bar', $headers);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $middleware->process($request, $handler);
+
+        self::assertCount(
+            $shouldBeCalled ? 1 : 0,
+            $profiler->tagsList
+        );
+    }
+
+    public static function dataWithHttpHeaders(): iterable
+    {
+        yield 'env = "true"; no headers' => [
+            'true',
+            [],
+            true
+        ];
+
+        yield 'env = "1"; no headers' => [
+            '1',
+            [],
+            true
+        ];
+
+        yield 'env = 1; no headers' => [
+            1,
+            [],
+            true
+        ];
+
+        yield 'env = 0; no headers' => [
+            0,
+            [],
+            false
+        ];
+
+        yield 'env = "0"; no headers' => [
+            '0',
+            [],
+            false
+        ];
+
+        yield 'env = "false"; no headers' => [
+            'false',
+            [],
+            false
+        ];
+
+        yield 'env = "true"; headers = "false"' => [
+            'true',
+            ['X-Spiral-Profiler-Enable' => 'false'],
+            false
+        ];
+
+        yield 'env = "false"; headers = "true"' => [
+            'false',
+            ['X-Spiral-Profiler-Enable' => 'true'],
+            true
+        ];
+
+        yield 'env = "false"; headers = "false"' => [
+            'false',
+            ['X-Spiral-Profiler-Enable' => 'false'],
+            false
+        ];
+
+        yield 'env = "true"; headers = "true"' => [
+            'false',
+            ['X-Spiral-Profiler-Enable' => 'true'],
+            true
+        ];
+
+        yield 'env = "0"; headers = "1"' => [
+            '0',
+            ['X-Spiral-Profiler-Enable' => '1'],
+            true
+        ];
+    }
+
     private function mockProfiler(): object
     {
         return new class () {
             public function __construct(
                 public array $tagsList = []
-            ) {
+            )
+            {
             }
 
             public function start(array $ignoredFunctions = []): void

--- a/tests/ProfilerMiddlewareTest.php
+++ b/tests/ProfilerMiddlewareTest.php
@@ -6,10 +6,14 @@ namespace Spiral\Profiler\Tests;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Spiral\Boot\Environment;
 use Spiral\Boot\EnvironmentInterface;
 use Spiral\Core\CoreInterface;
 use Spiral\Core\FactoryInterface;
 use Spiral\Profiler\ProfilerInterceptor;
+use Spiral\Profiler\ProfilerMiddleware;
 
 /**
  * @coversDefaultClass \Spiral\Profiler\ProfilerMiddleware
@@ -29,13 +33,14 @@ final class ProfilerMiddlewareTest extends TestCase
         $container = $this->createMock(ContainerInterface::class);
         $container->method('has')->willReturn(false);
 
-        $interceptor = new ProfilerInterceptor(
+        $middleware = new ProfilerMiddleware(
             $factory,
             $container,
-            $this->createMock(EnvironmentInterface::class),
+            new Environment()
         );
-        $core = $this->createMock(CoreInterface::class);
-        $interceptor->process('foo', 'bar', [], $core);
+        $request = $this->createMock(ServerRequestInterface::class);
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $middleware->process($request, $handler);
 
         self::assertCount(1, $profiler->tagsList);
         self::assertArrayHasKey('dispatcher', $tags = $profiler->tagsList[0]);


### PR DESCRIPTION
By default, middleware start profiling on every request. Н
You can configure profiling to be enabled only for certain requests.

1. Set env variable PROFILER_MIDDLEWARE_DEFAULT_ENABLED to false.
```dotenv
PROFILER_MIDDLEWARE_DEFAULT_ENABLED=false
```

2. Pass Http header `X-Spiral-Profiler-Enable=1` for request you want to profile.